### PR TITLE
fix: drive PID

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -57,7 +57,7 @@ public final class Constants {
         new Translation2d(kWheelBase / 2, kTrackWidth / 2), new Translation2d(-kWheelBase / 2, kTrackWidth / 2),
         new Translation2d(kWheelBase / 2, -kTrackWidth / 2), new Translation2d(-kWheelBase / 2, -kTrackWidth / 2));
 
-    public static final double kMaxSpeedMetersPerSecond = 3;
+    public static final double kMaxSpeedMetersPerSecond = 3.6;
 
     public static final double kMaxAngularSpeedRadiansPerSecond = 8.76;
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -39,13 +39,13 @@ public class RobotContainer {
     configureButtonBindings();
     DoubleSupplier x = () -> Utils
         .oddSquare(Utils.deadZone(-m_driveController.getLeftY(), OIConstants.kJoystickDeadzone))
-        * SwerveConstants.kMaxSpeedMetersPerSecond * 0.2;
+        * SwerveConstants.kMaxSpeedMetersPerSecond;
     DoubleSupplier y = () -> Utils
         .oddSquare(Utils.deadZone(-m_driveController.getLeftX(), OIConstants.kJoystickDeadzone))
-        * SwerveConstants.kMaxSpeedMetersPerSecond * 0.2;
+        * SwerveConstants.kMaxSpeedMetersPerSecond;
     DoubleSupplier rot = () -> Utils
         .oddSquare(Utils.deadZone(-m_driveController.getRightX(), OIConstants.kJoystickDeadzone))
-        * SwerveConstants.kMaxAngularSpeedRadiansPerSecond * 0.2;
+        * SwerveConstants.kMaxAngularSpeedRadiansPerSecond;
     m_swerveDriveSubsystem.setDefaultCommand(
         new SwerveDriveCommand(m_swerveDriveSubsystem, x, y, rot, () -> m_driveController.getRightBumper()));
 

--- a/src/main/java/frc/robot/subsystems/SwerveDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveDriveSubsystem.java
@@ -58,6 +58,16 @@ public class SwerveDriveSubsystem extends SubsystemBase {
     SmartDashboard.putNumber("Module Speed Front Right", m_frontRight.getState().speedMetersPerSecond);
     SmartDashboard.putNumber("Module Speed Rear Right", m_rearRight.getState().speedMetersPerSecond);
 
+    SmartDashboard.putNumber("Desired Module Speed Front Left", m_frontLeft.getDesiredState().speedMetersPerSecond);
+    SmartDashboard.putNumber("Desired Module Speed Rear Left", m_rearLeft.getDesiredState().speedMetersPerSecond);
+    SmartDashboard.putNumber("Desired Module Speed Front Right", m_frontRight.getDesiredState().speedMetersPerSecond);
+    SmartDashboard.putNumber("Desired Module Speed Rear Right", m_rearRight.getDesiredState().speedMetersPerSecond);
+
+    SmartDashboard.putNumber("Module Speed Difference Front Left", m_frontLeft.getDesiredState().speedMetersPerSecond / m_frontLeft.getState().speedMetersPerSecond);
+    SmartDashboard.putNumber("Module Speed Difference Rear Left", m_rearLeft.getDesiredState().speedMetersPerSecond / m_rearLeft.getState().speedMetersPerSecond);
+    SmartDashboard.putNumber("Module Speed Difference Front Right", m_frontRight.getDesiredState().speedMetersPerSecond / m_frontRight.getState().speedMetersPerSecond);
+    SmartDashboard.putNumber("Module Speed Difference Rear Right", m_rearRight.getDesiredState().speedMetersPerSecond / m_rearRight.getState().speedMetersPerSecond);
+
     SmartDashboard.putNumber("Odometry X", m_odometry.getPoseMeters().getX());
     SmartDashboard.putNumber("Odometry Y", m_odometry.getPoseMeters().getY());
     SmartDashboard.putNumber("Odometry Rot", m_odometry.getPoseMeters().getRotation().getDegrees());
@@ -109,10 +119,10 @@ public class SwerveDriveSubsystem extends SubsystemBase {
 
       SwerveDriveKinematics.desaturateWheelSpeeds(swerveModuleStates, SwerveConstants.kMaxSpeedMetersPerSecond);
 
-      m_frontLeft.setDesiredState(swerveModuleStates[0]);
-      m_rearLeft.setDesiredState(swerveModuleStates[1]);
-      m_frontRight.setDesiredState(swerveModuleStates[2]);
-      m_rearRight.setDesiredState(swerveModuleStates[3]);
+      m_frontLeft.setDesiredState(swerveModuleStates[0], 1.12);
+      m_rearLeft.setDesiredState(swerveModuleStates[1], 1.11);
+      m_frontRight.setDesiredState(swerveModuleStates[2], 1.2);
+      m_rearRight.setDesiredState(swerveModuleStates[3], 1.23);
     }
 
     SmartDashboard.putNumber("Desired X", xSpeed);

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -20,6 +20,8 @@ public class SwerveModule {
 
   private final AbsoluteEncoder m_turningEncoder;
 
+  // TODO Tune PIDs.
+  private final PIDController m_drivePIDController = new PIDController(0.1, 0, 0);
   private final PIDController m_turningPIDController = new PIDController(0.3, 0, 0);
 
   /**
@@ -69,7 +71,9 @@ public class SwerveModule {
   public void setDesiredState(SwerveModuleState desiredState) {
     SwerveModuleState state = SwerveModuleState.optimize(desiredState, m_turningEncoder.get());
 
-    final double driveOutput = state.speedMetersPerSecond;
+    final double driveOutput = m_drivePIDController.calculate(m_driveMotor.getEncoder().getVelocity()
+        * ModuleConstants.kWheelCircumferenceMeters / 60 / ModuleConstants.kDrivingGearRatio,
+        state.speedMetersPerSecond);
     final double turnOutput = m_turningPIDController.calculate(m_turningEncoder.get().getRadians(),
         state.angle.getRadians());
 

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -21,7 +21,7 @@ public class SwerveModule {
   private final AbsoluteEncoder m_turningEncoder;
 
   // TODO Tune PIDs.
-  private final PIDController m_drivePIDController = new PIDController(0.1, 0, 0);
+  private final PIDController m_drivePIDController = new PIDController(0.3, 0.8, 0);
   private final PIDController m_turningPIDController = new PIDController(0.3, 0, 0);
 
   /**
@@ -39,6 +39,7 @@ public class SwerveModule {
 
     m_turningEncoder = turningEncoder;
 
+    m_drivePIDController.setIntegratorRange(0, 1);
     m_turningPIDController.enableContinuousInput(-Math.PI, Math.PI);
     m_driveMotor.setIdleMode(IdleMode.kBrake);
     m_turningMotor.setIdleMode(IdleMode.kBrake);

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -21,7 +21,7 @@ public class SwerveModule {
   private final AbsoluteEncoder m_turningEncoder;
 
   // TODO Tune PIDs.
-  private final PIDController m_drivePIDController = new PIDController(0.3, 0.8, 0);
+  private final PIDController m_drivePIDController = new PIDController(0.3, 0.8, 0.025);
   private final PIDController m_turningPIDController = new PIDController(0.3, 0, 0);
 
   /**


### PR DESCRIPTION
added a PID controller to control the drive output.
1. This should fix the problem where the robot drifts while driving, which means heading correction is useless. The reason I think the robot drifts is because one side is heavier than the other, but all wheels are given equal power, when the wheels on the heavier side should be given more power. This PID will look at the current speed of the wheel and give it more power if it is below the desired speed, therefore correcting the drift.
2. m_driveMotor.set() takes in a value from -1 to 1 but we pass in a meters per second value, so a PID would fix this.
Needs to be tuned before being marked ready for review