### PR TITLE
fix: selection of paths in smart dashboard

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -104,6 +104,8 @@ public class RobotContainer {
 				m_climberSubsystem.set(leftClimbSpeed.getAsDouble());
 			}
 		}, m_climberSubsystem));
+
+		SmartDashboard.putString("Autonomous Path", "Type Path Name Here");
 	}
 
 	/**
@@ -177,11 +179,11 @@ public class RobotContainer {
 				new ArmCommand(m_shooterSubsystem, ShooterConstants.kLowerArmAngle),
 				new ParallelCommandGroup(
 						new PathWeaverCommand(m_swerveDriveSubsystem,
-								SmartDashboard.getString("AutonPath", "BlueHangarTwoBall") + "1", true),
+								SmartDashboard.getString("Autonomous Path", "BlueHangar") + "TwoBall1", true),
 						new IntakeCommand(m_shooterSubsystem)),
 				new ArmCommand(m_shooterSubsystem, ShooterConstants.kUpperArmAngle),
 				new PathWeaverCommand(m_swerveDriveSubsystem,
-						SmartDashboard.getString("AutonPath", "BlueHangarTwoBall") + "2", false),
+						SmartDashboard.getString("Autonomous Path", "BlueHangar") + "TwoBall2", false),
 				new ShootCommand(m_shooterSubsystem));
 	}
 }


### PR DESCRIPTION
You need to type the path name into SmartDashboard under the "Autonomous Path" option. Be sure to press enter to save it. Examples include "BlueHanger" and "RedHangar".