### PR TITLE
fix: calibrated the intake arm

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -91,8 +91,8 @@ public final class Constants {
 		public static final double kBottomShooterSpeedRPM = 2100;
 		public static final double kTopShooterSpeedRPM = 5300;
 
-		public static final int kLowerArmAngle = 50;
-		public static final int kUpperArmAngle = -50;
+		public static final double kLowerArmAngle = 50.6;
+		public static final double kUpperArmAngle = -54.6;
 		public static final double kIntakeSpeed = 0.7;
 		public static final double kTopFeederSpeedSlow = 0.1;
 		public static final double kTopFeederSpeedFast = 0.9;

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -76,6 +76,7 @@ public class ShooterSubsystem extends SubsystemBase {
 		m_bottomShooterPID.setTolerance(0.08 * ShooterConstants.kTopShooterSpeedRPM, 100 / 0.02);
 		m_topShooterPID.setTolerance(0.08 * ShooterConstants.kBottomShooterSpeedRPM, 100 / 0.02);
 		m_armPID.setTolerance(2);
+		m_armPID.enableContinuousInput(-180, 180);
 
 		// m_feederTimer.start();
 	}


### PR DESCRIPTION
- calibrated intake arm up/in and down/out encoder setpoints
- made pid continuous (-180, 180), though it was working fine without this feature
- changed intake setpoints from `int`s to `double`s.  not a crucial change.  but.  why were they doubles in the first place?!